### PR TITLE
Support adding a dict in a new key

### DIFF
--- a/jabstract/__init__.py
+++ b/jabstract/__init__.py
@@ -4,7 +4,7 @@ import copy
 def apply_kwargs(kwargs, default_kwargs):
     for k, v in kwargs.items():
         if isinstance(v, dict):
-            default_kwargs[k] = apply_kwargs(v, default_kwargs[k])
+            default_kwargs[k] = apply_kwargs(v, default_kwargs.get(k, {}))
         else:
             default_kwargs[k] = v
     return default_kwargs

--- a/test/test_jabstract.py
+++ b/test/test_jabstract.py
@@ -40,4 +40,18 @@ class TestJabstract(unittest.TestCase):
         self.assertEqual(response1["client"]["name"], "Baboon v2.0")
         self.assertEqual(response2["client"]["name"], "Baboon v3.7")
 
+    def test_jabstract_lets_you_add_a_section_because_some_apis_are_weird_and_fields_are_optionnal(self):
+        api_response = jabstract({
+            "client": {
+                "name": "John doe",
+            }
+        })
 
+        response = api_response(
+            client=dict(
+                car=dict(
+                    color="blue")
+            )
+        )
+
+        self.assertEqual(response["client"]["car"]["color"], "blue")


### PR DESCRIPTION
Some apis have sections appearing with a param or just because they feel
like it.

Trying to add a dict in a new key was causing a problem when the key did
not exist before hand.